### PR TITLE
Dev

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,9 @@ Versionsänderungen:
 ####Version 2.1.13:
 
 - Bugfix #159: Leere Zwischenüberschrift in Sidebar
-- Bei Sprechzeitenausgabe wird Content in div anstelle span ausgegeben, da sonst invalides HTML 
+- Bei Sprechzeitenausgabe wird Content in div anstelle span ausgegeben, da sonst invalides HTML
+- Bild in widget nun parametrisierbar über Parameter bild. 
+   Default in FAU-Einrichtungen: Bild in kleiner Inline-Sidebar = 0. 
 
 ####Version 2.1.12:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,13 @@ showfax *, showwebsite *, showaddress *, showroom *, showdescription *, showlist
 Versionsänderungen:
 ===================
 
+####Version 2.1.12:
+
+- Bugfix #157 bei der Anzeige der Personenseite:
+  Kontaktpersonen besser formatiert.
+- Bugfix #153 bei Anzeige von Kontakten ohne Bild
+  
+    
 ####Version 2.1.11:    
 
 - Bugfix für Einbindung leere Kategorie    

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,12 @@ showfax *, showwebsite *, showaddress *, showroom *, showdescription *, showlist
 Versionsänderungen:
 ===================
 
+
+####Version 2.1.13:
+
+- Bugfix #159: Leere Zwischenüberschrift in Sidebar
+- Bei Sprechzeitenausgabe wird Content in div anstelle span ausgegeben, da sonst invalides HTML 
+
 ####Version 2.1.12:
 
 - Bugfix #157 bei der Anzeige der Personenseite:

--- a/fau-person.php
+++ b/fau-person.php
@@ -4,7 +4,7 @@
  Plugin Name: FAU Person
  Plugin URI: https://github.com/RRZE-Webteam/fau-person
  * Description: Visitenkarten-Plugin für FAU Webauftritte
- * Version: 2.1.12
+ * Version: 2.1.13
  * Author: RRZE-Webteam
  * Author URI: http://blogs.fau.de/webworking/
  * License: GPLv2 or later
@@ -44,7 +44,7 @@ require_once('shortcodes/fau-standort-shortcodes.php');
 class FAU_Person {
 
     //******** Mit neuer Version auch hier aktualisieren!!! ***********
-    const version = '2.1.11';
+    const version = '2.1.13';
     
     const option_name = '_fau_person';
     const version_option_name = '_fau_person_version';

--- a/fau-person.php
+++ b/fau-person.php
@@ -4,7 +4,7 @@
  Plugin Name: FAU Person
  Plugin URI: https://github.com/RRZE-Webteam/fau-person
  * Description: Visitenkarten-Plugin für FAU Webauftritte
- * Version: 2.1.11
+ * Version: 2.1.12
  * Author: RRZE-Webteam
  * Author URI: http://blogs.fau.de/webworking/
  * License: GPLv2 or later

--- a/shortcodes/fau-person-shortcodes.php
+++ b/shortcodes/fau-person-shortcodes.php
@@ -568,7 +568,8 @@ class FAU_Person_Shortcodes {
         $content = '<div class="person content-person" itemscope itemtype="http://schema.org/Person">';	
         if( $compactindex )     $content .= '<div class="compactindex">';
         
-        if( !$compactindex || $showthumb )        $content .= '<div class="row">';
+        // if( !$compactindex || $showthumb )        
+	$content .= '<div class="row">';
 
         if($showthumb) {
             $content .= '<div class="span1 span-small" itemprop="image">';	
@@ -595,7 +596,11 @@ class FAU_Person_Shortcodes {
         }
   
         if( $compactindex ) {
-            if( $showthumb )   $content .= '<div class="span6">';
+            if( $showthumb ) {
+		$content .= '<div class="span6">';
+	    } else {
+		$content .= '<div class="span7">';
+	    }
         } else {
             if( $showthumb ) {
                 $content .= '<div class="span3">';
@@ -607,33 +612,41 @@ class FAU_Person_Shortcodes {
         $content .= '<a title="' . sprintf(__('Weitere Informationen zu %s aufrufen', FAU_PERSON_TEXTDOMAIN), get_the_title($id)) . '" href="' . $personlink . '">' . $fullname . '</a>';
         $content .= '</h3>';
         $content .= '<ul class="person-info">';
-        if ($showposition && $jobTitle)
-            $content .= '<li class="person-info-position"><span class="screen-reader-text">' . __('Tätigkeit', FAU_PERSON_TEXTDOMAIN) . ': </span><strong><span itemprop="jobTitle">' . $jobTitle . '</span></strong></li>';
-        if ($showinstitution && $worksFor)
-            $content .= '<li class="person-info-institution"><span class="screen-reader-text">' . __('Organisation', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="worksFor">' . $worksFor . '</span></li>';
-        if ($showabteilung && $department)
-            $content .= '<li class="person-info-abteilung"><span class="screen-reader-text">' . __('Abteilung', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="department">' . $department . '</span></li>';
-        if (($extended || $showaddress) && !empty($contactpoint)  && empty( $connection_only ) ) 
-            $content .= $contactpoint;
-        if ($showtelefon && $telephone  && empty( $connection_only ) )
-            $content .= '<li class="person-info-phone"><span class="screen-reader-text">' . __('Telefonnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="telephone">' . $telephone . '</span></li>';
-        if ($showmobile && $mobilePhone  && empty( $connection_only ) )
-            $content .= '<li class="person-info-mobile"><span class="screen-reader-text">' . __('Mobil', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="mobilePhone">' . $mobilePhone . '</span></li>';
-        if ($showfax && $faxNumber  && empty( $connection_only ) )
-            $content .= '<li class="person-info-fax"><span class="screen-reader-text">' . __('Faxnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="faxNumber">' . $faxNumber . '</span></li>';
-        if ($showmail && $email  && empty( $connection_only ) )
-            $content .= '<li class="person-info-email"><span class="screen-reader-text">' . __('E-Mail', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="email" href="mailto:' . strtolower($email) . '">' . strtolower($email) . '</a></li>';
-        if ($showwebsite && $url)
-            $content .= '<li class="person-info-www"><span class="screen-reader-text">' . __('Webseite', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="url" href="' . $url . '">' . $url . '</a></li>';
-        if ($showpubs && $pubs)
-            $content .= '<li class="person-info-pubs"><span class="screen-reader-text">' . __('Publikationen', FAU_PERSON_TEXTDOMAIN) . ': </span>' . $pubs . '</li>';
+	    if ($showposition && $jobTitle)
+		$content .= '<li class="person-info-position"><span class="screen-reader-text">' . __('Tätigkeit', FAU_PERSON_TEXTDOMAIN) . ': </span><strong><span itemprop="jobTitle">' . $jobTitle . '</span></strong></li>';
+	    if ($showinstitution && $worksFor)
+		$content .= '<li class="person-info-institution"><span class="screen-reader-text">' . __('Organisation', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="worksFor">' . $worksFor . '</span></li>';
+	    if ($showabteilung && $department)
+		$content .= '<li class="person-info-abteilung"><span class="screen-reader-text">' . __('Abteilung', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="department">' . $department . '</span></li>';
+	    if (($extended || $showaddress) && !empty($contactpoint)  && empty( $connection_only ) ) 
+		$content .= $contactpoint;
+	    if ($showtelefon && $telephone  && empty( $connection_only ) )
+		$content .= '<li class="person-info-phone"><span class="screen-reader-text">' . __('Telefonnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="telephone">' . $telephone . '</span></li>';
+	    if ($showmobile && $mobilePhone  && empty( $connection_only ) )
+		$content .= '<li class="person-info-mobile"><span class="screen-reader-text">' . __('Mobil', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="mobilePhone">' . $mobilePhone . '</span></li>';
+	    if ($showfax && $faxNumber  && empty( $connection_only ) )
+		$content .= '<li class="person-info-fax"><span class="screen-reader-text">' . __('Faxnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="faxNumber">' . $faxNumber . '</span></li>';
+	    if ($showmail && $email  && empty( $connection_only ) )
+		$content .= '<li class="person-info-email"><span class="screen-reader-text">' . __('E-Mail', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="email" href="mailto:' . strtolower($email) . '">' . strtolower($email) . '</a></li>';
+	    if ($showwebsite && $url)
+		$content .= '<li class="person-info-www"><span class="screen-reader-text">' . __('Webseite', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="url" href="' . $url . '">' . $url . '</a></li>';
+	    if ($showpubs && $pubs)
+		$content .= '<li class="person-info-pubs"><span class="screen-reader-text">' . __('Publikationen', FAU_PERSON_TEXTDOMAIN) . ': </span>' . $pubs . '</li>';
         $content .= '</ul>';
+	
+	
         if ( (!empty($connection_text) || !empty($connection_options) || !empty($connections))  && $showvia===1 )
             $content .= self::fau_person_connection( $connection_text, $connection_options, $connections );
 
-        if( !($compactindex && $showthumb) )      $content .= '</div>';
-        if (($showoffice && $hoursAvailable  && empty( $connection_only )) || ($showlist && isset($excerpt)) || (($showsidebar || $extended) && $description) || ($showlink && $personlink)) {
-            if( !$compactindex )    $content .= '<div class="span3">';
+      //  if( !($compactindex && $showthumb) )      $content .= '</div>';
+	
+        if (($showoffice && $hoursAvailable  && empty( $connection_only )) 
+		|| ($showlist && isset($excerpt))
+	        || (($showsidebar || $extended) && $description) 
+		|| ($showlink && $personlink)) {
+	    
+	    
+            if( !$compactindex )    $content .= '</div><div class="span3">';
             if ($showoffice && $hoursAvailable  && empty( $connection_only ) ) {
                 $content .= '<ul class="person-info">';
                 $content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</span></li>';
@@ -650,9 +663,15 @@ class FAU_Person_Shortcodes {
             }
             if( !$compactindex )    $content .= '</div>';
         }
-        if( $compactindex && $showthumb )      $content .= '</div>';
-        if( !$compactindex || $showthumb )      $content .= '</div>';
-        if( $compactindex )     $content .= '</div>';
+	
+	
+        // if( $compactindex && $showthumb )      
+	$content .= '</div>'; // end div row
+
+	// if( !$compactindex || $showthumb )      
+	$content .= '</div> <!-- /row-->'; 
+
+        if( $compactindex )     $content .= '</div>';   // ende div class compactindex
         $content .= '</div>';
         return $content;
     }
@@ -705,6 +724,8 @@ class FAU_Person_Shortcodes {
             $fullname .= '<span itemprop="familyName">' . $familyName . '</span>';
         if ($honorificSuffix)
             $fullname .= ', <span itemprop="honorificSuffix">' . $honorificSuffix . '</span>';
+	
+	
         $content .= '<h2 itemprop="name">' . $fullname . '</h2>';
         $post = get_post($id);
         if (has_post_thumbnail($id)) {
@@ -728,7 +749,7 @@ class FAU_Person_Shortcodes {
             $content .= '<li class="person-info-fax"><span class="screen-reader-text">' . __('Faxnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="faxNumber">' . $faxNumber . '</span></li>';
         if ( $email && empty( $connection_only ) )
             $content .= '<li class="person-info-email"><span class="screen-reader-text">' . __('E-Mail', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="email" href="mailto:' . strtolower($email) . '">' . strtolower($email) . '</a></li>';
-        if ( $url )
+        if ( $url && empty( $connection_only ) )
             $content .= '<li class="person-info-www"><span class="screen-reader-text">' . __('Webseite', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="url" href="' . $url . '">' . $url . '</a></li>';
         if ( !empty( $contactpoint ) && empty( $connection_only ) ) {
             $content .= $contactpoint;
@@ -740,8 +761,18 @@ class FAU_Person_Shortcodes {
         if ( $pubs )
             $content .= '<li class="person-info-pubs"><span class="screen-reader-text">' . __('Publikationen', FAU_PERSON_TEXTDOMAIN) . ': </span>' . $pubs . '</li>';
         $content .= '</ul>';
+	
         if ( !empty($connection_text) || !empty($connection_options) || !empty($connections) )
             $content .= self::fau_person_connection( $connection_text, $connection_options, $connections );
+	
+	
+	
+	$post = get_post( $id );
+        if ( $post->post_content ) {
+	   $content .= '<div class="desc" itemprop="description">';
+	   $content .= $post->post_content; 
+	   $content .= '</div>';
+	}
         $content .= '</div>';
 
         //	    if (($options['plugin_fau_person_headline'] != 'jobTitle') && ($position)) 
@@ -909,15 +940,14 @@ class FAU_Person_Shortcodes {
     }
     
     public static function fau_person_connection( $connection_text, $connection_options, $connections ) {
+       
         $content = '';
-        if( $connection_text ) {
-            $content .= '<h3 itemprop="name">' . $connection_text . '</h3>';
-        }
-  
+	$contactlist = '';
         foreach ( $connections as $key => $value ) {
             extract ( $connections[$key] );
             $fullname = '';
             $contactpoint = '';      
+	       
             if ( $honorificPrefix )            $fullname .= '<span itemprop="honorificPrefix">'.$honorificPrefix."</span> ";
                 if( $givenName || $familyName ) {
                     if ( $givenName )          $fullname .= '<span itemprop="givenName">'.$givenName."</span> ";
@@ -957,25 +987,41 @@ class FAU_Person_Shortcodes {
             }    
             $contactpoint .= '</li>';
             
-            $content .= '<ul class="person-info">';
-                $content .= '<li itemprop="name">' . $fullname . '</li>';
-            if ( $connection_options ) {
-                if ( $telephone && in_array( 'telephone', $connection_options ) )
-                    $content .= '<li class="person-info-phone"><span class="screen-reader-text">' . __('Telefonnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="telephone">' . $telephone . '</span></li>';
-                if ( isset($mobilePhone) && in_array( 'telephone', $connection_options ) ) 
-                    $content .= '<li class="person-info-mobile"><span class="screen-reader-text">' . __('Mobiltelefon', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="mobilePhone">' . $mobilePhone . '</span></li>';
-                if ( $faxNumber && in_array( 'faxNumber', $connection_options ) )
-                    $content .= '<li class="person-info-fax"><span class="screen-reader-text">' . __('Faxnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="faxNumber">' . $faxNumber . '</span></li>';
-                if ( $email && in_array( 'email', $connection_options ) )
-                    $content .= '<li class="person-info-email"><span class="screen-reader-text">' . __('E-Mail', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="email" href="mailto:' . strtolower($email) . '">' . strtolower($email) . '</a></li>';
-                if ( !empty( $contactpoint ) && in_array( 'contactPoint', $connection_options ) )
-                    $content .= $contactpoint;
-                if ( $hoursAvailable && in_array( 'hoursAvailable', $connection_options ) )
-                    $content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</span></li>';
-                }
-                $content .= '</ul>';    
-                
-        }        
+	    $contactlist .= '<li itemprop="name" itemscope itemtype="http://schema.org/Person">' . $fullname;
+		if ( $connection_options ) {
+		    
+		    $contactlist .= '<ul class="person-info">';
+		    
+		    if ( $telephone && in_array( 'telephone', $connection_options ) )
+			$content .= '<li class="person-info-phone"><span class="screen-reader-text">' . __('Telefonnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="telephone">' . $telephone . '</span></li>';
+		    if ( isset($mobilePhone) && in_array( 'telephone', $connection_options ) ) 
+			$content .= '<li class="person-info-mobile"><span class="screen-reader-text">' . __('Mobiltelefon', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="mobilePhone">' . $mobilePhone . '</span></li>';
+		    if ( $faxNumber && in_array( 'faxNumber', $connection_options ) )
+			$content .= '<li class="person-info-fax"><span class="screen-reader-text">' . __('Faxnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="faxNumber">' . $faxNumber . '</span></li>';
+		    if ( $email && in_array( 'email', $connection_options ) )
+			$content .= '<li class="person-info-email"><span class="screen-reader-text">' . __('E-Mail', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="email" href="mailto:' . strtolower($email) . '">' . strtolower($email) . '</a></li>';
+		    if ( !empty( $contactpoint ) && in_array( 'contactPoint', $connection_options ) )
+			$content .= $contactpoint;
+		    if ( $hoursAvailable && in_array( 'hoursAvailable', $connection_options ) )
+			$content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</span></li>';
+	
+		    $contactlist .= '</ul>';
+		    
+		}
+	    $contactlist .= '</li>';
+        }       
+	
+	if (!empty($contactlist)) {
+	    $content = '<div class="connection">';
+	    if( $connection_text ) {
+		 $content .= '<h3>' . $connection_text . '</h3>';		 
+	    }
+	    $content .= '<ul class="connection-list">';
+	    $content .= $contactlist;
+	    $content .= '</ul>';
+	    $content .= '</div>';    
+	}
+	
         return $content;
     }
 }

--- a/shortcodes/fau-person-shortcodes.php
+++ b/shortcodes/fau-person-shortcodes.php
@@ -924,7 +924,7 @@ class FAU_Person_Shortcodes {
             if ( $url && $showwebsite )
                 $content .= '<li class="person-info-www"><span class="screen-reader-text">' . __('Webseite', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="url" href="' . $url . '">' . $url . '</a></li>' . "\n";
             if ( $hoursAvailable && $showoffice  && empty( $connection_only ) )
-                $content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</span></li>';
+                $content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><div itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</div></li>';
             $content .= '</ul>' . "\n";
             if ( ( !empty($connection_text) || !empty($connection_options) || !empty($connections) ) && $showvia===1  )
                 $content .= self::fau_person_connection( $connection_text, $connection_options, $connections );
@@ -988,25 +988,28 @@ class FAU_Person_Shortcodes {
             $contactpoint .= '</li>';
             
 	    $contactlist .= '<li itemprop="name" itemscope itemtype="http://schema.org/Person">' . $fullname;
+	   
 		if ( $connection_options ) {
-		    
-		    $contactlist .= '<ul class="person-info">';
-		    
+		    $cinfo = '';
+
 		    if ( $telephone && in_array( 'telephone', $connection_options ) )
-			$content .= '<li class="person-info-phone"><span class="screen-reader-text">' . __('Telefonnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="telephone">' . $telephone . '</span></li>';
+			$cinfo .= '<li class="person-info-phone"><span class="screen-reader-text">' . __('Telefonnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="telephone">' . $telephone . '</span></li>';
 		    if ( isset($mobilePhone) && in_array( 'telephone', $connection_options ) ) 
-			$content .= '<li class="person-info-mobile"><span class="screen-reader-text">' . __('Mobiltelefon', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="mobilePhone">' . $mobilePhone . '</span></li>';
+			$cinfo .= '<li class="person-info-mobile"><span class="screen-reader-text">' . __('Mobiltelefon', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="mobilePhone">' . $mobilePhone . '</span></li>';
 		    if ( $faxNumber && in_array( 'faxNumber', $connection_options ) )
-			$content .= '<li class="person-info-fax"><span class="screen-reader-text">' . __('Faxnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="faxNumber">' . $faxNumber . '</span></li>';
+			$cinfo .= '<li class="person-info-fax"><span class="screen-reader-text">' . __('Faxnummer', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="faxNumber">' . $faxNumber . '</span></li>';
 		    if ( $email && in_array( 'email', $connection_options ) )
-			$content .= '<li class="person-info-email"><span class="screen-reader-text">' . __('E-Mail', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="email" href="mailto:' . strtolower($email) . '">' . strtolower($email) . '</a></li>';
+			$cinfo .= '<li class="person-info-email"><span class="screen-reader-text">' . __('E-Mail', FAU_PERSON_TEXTDOMAIN) . ': </span><a itemprop="email" href="mailto:' . strtolower($email) . '">' . strtolower($email) . '</a></li>';
 		    if ( !empty( $contactpoint ) && in_array( 'contactPoint', $connection_options ) )
-			$content .= $contactpoint;
+			$cinfo .= $contactpoint;
 		    if ( $hoursAvailable && in_array( 'hoursAvailable', $connection_options ) )
-			$content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</span></li>';
-	
-		    $contactlist .= '</ul>';
+			$cinfo .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</span></li>';
 		    
+		    if (!empty($cinfo)) {
+			$contactlist .= '<ul class="person-info">';
+			$contactlist .= $cinfo;
+			$contactlist .= '</ul>';
+		    }
 		}
 	    $contactlist .= '</li>';
         }       

--- a/shortcodes/fau-person-shortcodes.php
+++ b/shortcodes/fau-person-shortcodes.php
@@ -649,7 +649,7 @@ class FAU_Person_Shortcodes {
             if( !$compactindex )    $content .= '</div><div class="span3">';
             if ($showoffice && $hoursAvailable  && empty( $connection_only ) ) {
                 $content .= '<ul class="person-info">';
-                $content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><span itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</span></li>';
+                $content .= '<li class="person-info-office"><span class="screen-reader-text">' . __('Sprechzeiten', FAU_PERSON_TEXTDOMAIN) . ': </span><div itemprop="hoursAvailable" itemtype="http://schema.org/ContactPoint">' . $hoursAvailable . '</div></li>';
                 $content .= '</ul>';
             }
 
@@ -661,7 +661,6 @@ class FAU_Person_Shortcodes {
                 $content .= '<div class="person-info-more"><a title="' . sprintf(__('Weitere Informationen zu %s aufrufen', FAU_PERSON_TEXTDOMAIN), get_the_title($id)) . '" class="person-read-more" href="' . $personlink . '">';
                 $content .= __('Mehr', FAU_PERSON_TEXTDOMAIN) . ' ›</a></div>';
             }
-            if( !$compactindex )    $content .= '</div>';
         }
 	
 	

--- a/templates/single-person.php
+++ b/templates/single-person.php
@@ -11,7 +11,6 @@ get_header(); ?>
                     $id = $post->ID;
 
 		    echo FAU_Person_Shortcodes::fau_person_page($id);
-                    the_content();
 			?>
           
                     </div>

--- a/widgets/fau-person-widget.php
+++ b/widgets/fau-person-widget.php
@@ -58,7 +58,7 @@ class FAUPersonWidget extends WP_Widget {
 
         echo $before_widget;
         $id = empty($instance['id']) ? ' ' : $instance['id'];
-        $title = empty($instance['title']) ? ' ' : $instance['title'];
+        $title = empty($instance['title']) ? '' : $instance['title'];
         // Welche Felder sollen in der Sidebar angezeigt werden?
         $options = FAU_Person::$options['sidebar'];
         // fau_person_sidebar($id, $title, list 0, inst 1, abtielung 1, posi 1, titel 1, suffix 1, addresse 1, raum 1, tele 1, fax 1, handy 0, mail 1, url 1, mehrlink 0, kurzauszug 1, office 1, pubs 0, bild 1, via 0)

--- a/widgets/fau-person-widget.php
+++ b/widgets/fau-person-widget.php
@@ -54,15 +54,17 @@ class FAUPersonWidget extends WP_Widget {
     }
 
     public function widget($args, $instance) {
+	$options = FAU_Person::$options['sidebar'];
         extract($args, EXTR_SKIP);
 
         echo $before_widget;
         $id = empty($instance['id']) ? ' ' : $instance['id'];
         $title = empty($instance['title']) ? '' : $instance['title'];
+	$bild = empty($instance['bild']) ? $options['bild'] : $instance['bild'];
         // Welche Felder sollen in der Sidebar angezeigt werden?
-        $options = FAU_Person::$options['sidebar'];
+       
         // fau_person_sidebar($id, $title, list 0, inst 1, abtielung 1, posi 1, titel 1, suffix 1, addresse 1, raum 1, tele 1, fax 1, handy 0, mail 1, url 1, mehrlink 0, kurzauszug 1, office 1, pubs 0, bild 1, via 0)
-        echo FAU_Person_Shortcodes::fau_person_sidebar($id, $title, 0, $options['organisation'], $options['abteilung'], $options['position'], 1, 1, $options['adresse'], 1, $options['telefon'], $options['fax'], 0, $options['mail'], $options['webseite'], 0, $options['kurzauszug'], $options['sprechzeiten'], 0, $options['bild'], 0);
+        echo FAU_Person_Shortcodes::fau_person_sidebar($id, $title, 0, $options['organisation'], $options['abteilung'], $options['position'], 1, 1, $options['adresse'], 1, $options['telefon'], $options['fax'], 0, $options['mail'], $options['webseite'], 0, $options['kurzauszug'], $options['sprechzeiten'], 0, $bild, 0);
         echo $after_widget;
     }
 

--- a/widgets/fau-person-widget.php
+++ b/widgets/fau-person-widget.php
@@ -60,9 +60,11 @@ class FAUPersonWidget extends WP_Widget {
         echo $before_widget;
         $id = empty($instance['id']) ? ' ' : $instance['id'];
         $title = empty($instance['title']) ? '' : $instance['title'];
-	$bild = empty($instance['bild']) ? $options['bild'] : $instance['bild'];
-        // Welche Felder sollen in der Sidebar angezeigt werden?
-       
+	if (isset($instance['bild'])) {
+	    $bild = intval($instance['bild']);
+	} else {
+	    $bild = $options['bild'];
+	}
         // fau_person_sidebar($id, $title, list 0, inst 1, abtielung 1, posi 1, titel 1, suffix 1, addresse 1, raum 1, tele 1, fax 1, handy 0, mail 1, url 1, mehrlink 0, kurzauszug 1, office 1, pubs 0, bild 1, via 0)
         echo FAU_Person_Shortcodes::fau_person_sidebar($id, $title, 0, $options['organisation'], $options['abteilung'], $options['position'], 1, 1, $options['adresse'], 1, $options['telefon'], $options['fax'], 0, $options['mail'], $options['webseite'], 0, $options['kurzauszug'], $options['sprechzeiten'], 0, $bild, 0);
         echo $after_widget;


### PR DESCRIPTION

####Version 2.1.13:

- Bugfix #159: Leere Zwischenüberschrift in Sidebar
- Bei Sprechzeitenausgabe wird Content in div anstelle span ausgegeben, da sonst invalides HTML
- Bild in widget nun parametrisierbar über Parameter bild. 
   Default in FAU-Einrichtungen: Bild in kleiner Inline-Sidebar = 0. 

####Version 2.1.12:

- Bugfix #157 bei der Anzeige der Personenseite:
  Kontaktpersonen besser formatiert.
- Bugfix #153 bei Anzeige von Kontakten ohne Bild
  
    
####Version 2.1.11:    

- Bugfix für Einbindung leere Kategorie    