### PR TITLE
Fix um eigene Kontakt-Übersichtsseite zu ermöglichen

### DIFF
--- a/includes/Taxonomy/Kontakt.php
+++ b/includes/Taxonomy/Kontakt.php
@@ -47,8 +47,8 @@ class Kontakt extends Taxonomy {
 	    'not_found_in_trash'    => __('Keine Kontakte in Papierkorb gefunden', 'fau-person'),
         ];
 	$has_archive_page  = true;
-	if (isset($this->settings->options) && isset($this->settings->options['has_archive_page'])) {
-	    $has_archive_page = $this->settings->options['has_archive_page'];
+	if (isset($this->settings->options) && isset($this->settings->options['constants_has_archive_page'])) {
+	    $has_archive_page = $this->settings->options['constants_has_archive_page'];
 	}
 	$caps = get_fau_person_capabilities();
 	$person_args = array(


### PR DESCRIPTION
Diese Änderung behebt einen Fehler, wodurch die Einstellungsoption "**Kontakt-Übersichtsseite** - Zeige die Standard-Übersichtsseite aller Kontakte an. Bevor diese Option deaktiviert wird, muss eine eigene Seite mit der Titelform (slug) "person" direkt unterhalb der Hauptebene angelegt werden." ignoriert wird.

Behebt #332

Hinweis: Um eine eigene Kontakt-Übersichtsseite zu aktivieren, muss nach dem Setzen der Option scheinbar noch ein Cache geflushed werden -- z.B. durch kurzes De- und reaktivieren des Plugins.