### PR TITLE
Caching führt zu fehlerhafter Darstellung von Kontakten

### DIFF
--- a/includes/Shortcodes/Kontakt.php
+++ b/includes/Shortcodes/Kontakt.php
@@ -52,6 +52,7 @@ class Kontakt extends Shortcodes
         // Cache
         $content = get_transient(self::TRANSIENT_PREFIX . json_encode($arguments) . json_encode($displayfield));
         if (!empty($content)){
+            Main::enqueueForeignThemes();
             return $content;
         }else{
             $content = '';
@@ -210,6 +211,7 @@ class Kontakt extends Shortcodes
         // Cache
         $content = get_transient(self::TRANSIENT_PREFIX . json_encode($arguments) . json_encode($displayfield) . $limit);
         if (!empty($content)){
+            Main::enqueueForeignThemes();
             return $content;
         }else{
             $content = '';


### PR DESCRIPTION
# Pull Request-Beschreibung

Falls alle in einer Seite eingebundenen Kontakte aus dem Cache (siehe https://github.com/RRZE-Webteam/fau-person/commit/ca80cbad7c50244795212b12e1ee8b7493b767d9) geladen werden, führt dies dazu, dass das fau-person Stylesheet nicht geladen wird. Dementsprechend werden die Kontakte falsch dargestellt.

Ursache des ganzen ist, dass `Main::enqueueForeignThemes()` bisher nur beim Generieren der Kontakt-Darstellung aufgerufen wird, aber nicht wenn ein Eintrag aus dem Cache geladen wird.

# Weitere Analyse
Um die Frage zu beantworten warum das nicht sofort aufgefallen ist, muss ich etwas weiter ausholen. Der oben beschriebene Fehler ist nur bei Verwendung von memcached als persistentem Object Cache in Wordpress aufgetreten (per https://github.com/Automattic/wp-memcached ). Tatsächlich versteckt sich hinter dem ganzen aber das Problem, dass das Caching normalerweise gar nicht funktioniert.

[set_transient()](https://developer.wordpress.org/reference/functions/set_transient/) in Wordpress erlaubt nur Schlüssel bis zu 172 Zeichen. Ein Blick in den memached hat aber beispielsweise folgenden Eintrag zu Tage gefördert:
`wp_:transient:fau_person_cache_{"id":"1234","slug":"","category":"","hstart":3,"class":"","sort":"title","format":"shortlist","order":"asc","background":"","show":"","hide":""}{"honorificPrefix":true,"familyName":true,"givenName":tru`

Der Eintrag hat 233 Zeichen, was dazu führt, dass der Cache-Eintrag bei Verwendungs des Standard-Objekt-Caches kommentarlos verworfen wird. Die Liste der Attribute in `$arguments` ist dabei auch lang genug, damit dieser Fall _immer_ eintritt. Der oben zu sehende Fall, dass der Schlüssel abgeschnitten wird, könnte potentiell zu Cache-Kollisionen führen.

Als Lösung muss der für transient verwendete Schlüssel werden, z.B. indem dieser mit MD5/SHA256 gehasht wird.